### PR TITLE
machine_common: Fix inclusion of all lohit fonts.

### DIFF
--- a/machines/machine_common.nix
+++ b/machines/machine_common.nix
@@ -93,7 +93,6 @@
       font-awesome-ttf
       freefont_ttf
       hack-font
-      lohit-fonts
       powerline-fonts
       proggyfonts
       source-code-pro
@@ -106,6 +105,6 @@
       unifont
       vistafonts
       wqy_microhei
-    ];
+    ] ++ lib.filter lib.isDerivation (lib.attrValues lohit-fonts);
   };
 }


### PR DESCRIPTION
Since NixOS/nixpkgs@346dcab, `lohit-fonts` isn't a single derivation anymore and has been split up into an attrset consisting of the individual fonts.

So if we want to have all `lohit` fonts, we need to add all the values of the attribute set to the list of fonts (and filter out `.override` and other functions).
